### PR TITLE
Fix duration of trimmed videos when rangeTime is used on the exporter

### DIFF
--- a/Library/Sources/SCAssetExportSession.m
+++ b/Library/Sources/SCAssetExportSession.m
@@ -687,8 +687,8 @@ static CGContextRef SCCreateContextFromPixelBuffer(CVPixelBufferRef pixelBuffer)
     if (![_writer startWriting]) {
         EnsureSuccess(_writer.error, completionHandler);
     }
-    
-    [_writer startSessionAtSourceTime:kCMTimeZero];
+
+    [_writer startSessionAtSourceTime:_timeRange.start];
     
     _totalDuration = CMTimeGetSeconds(_inputAsset.duration);
 


### PR DESCRIPTION
Use _timeRange.start instead of kCMTimeZero to start writer session. This fixes the wrong duration on trimmed videos when the start is not 0